### PR TITLE
Lift driven by PID controller controller only

### DIFF
--- a/24-25_ReefScape_9082/src/main/java/frc/robot/Constants.java
+++ b/24-25_ReefScape_9082/src/main/java/frc/robot/Constants.java
@@ -68,6 +68,10 @@ public final class Constants {
     public static final double coralL2Height = 32.0; 
     public static final double coralL3Height = 48.0;
     public static final double coralL4Height = 75.0;
+
+    public static final double robotContainerFrequency = 50;  //RobotContainer and all robot code runs 50 times per second unless we change manually, which, we dont.
+    public static final double maxInchesPerSecond = 6;  //Number of inches per second we allow the lift setpoint to change in teleop
+    public static final double elementLiftTeleopJoystickScalingFactor = maxInchesPerSecond/robotContainerFrequency;
   }
   /*
    * Coral End Effector Constants

--- a/24-25_ReefScape_9082/src/main/java/frc/robot/RobotContainer.java
+++ b/24-25_ReefScape_9082/src/main/java/frc/robot/RobotContainer.java
@@ -305,25 +305,24 @@ public class RobotContainer {
              * elementLift.goToHeight(setPoint);
              */
 
-             //If throttle's down don't override PID.
+             //If throttle's down don't override PID and use PID controls.
              if (joystick2.getThrottle() > 0) {
-
-             
-            if(Math.abs(joystick2.getY()) > 0.065){  //Joystick deadzone of 0.065
-                setPoint = setPoint +(elementLiftConstants.elementLiftTeleopJoystickScalingFactor * -joystick2.getY());
-            }
-                //if below minimum 
+                if(Math.abs(-joystick2.getY()) > 0.065){  //Joystick deadzone of 0.065
+                    setPoint = setPoint +(elementLiftConstants.elementLiftTeleopJoystickScalingFactor * -joystick2.getY());
+                }
+                //if below minimum bring lift up to minimum. 
                 if(elementLift.getEncoderPosition() < elementLiftConstants.liftMinEncoder * elementLiftConstants.encoderToInches){
                     setPoint = setPoint + (elementLiftConstants.liftMinEncoder * elementLiftConstants.encoderToInches);  
                 }
-                //if above liftMaxHeight bring lift back down to the liftMaxHeight.
+                //if above liftMaxHeight bring lift down to the liftMaxHeight.
                 if(elementLift.getEncoderPosition() > elementLiftConstants.liftMaxEncoder * elementLiftConstants.encoderToInches){
                     setPoint = setPoint + (elementLiftConstants.liftMaxEncoder * elementLiftConstants.encoderToInches); 
                 }
                 elementLift.goToHeight(setPoint);      
             }
-            else {
-                
+            //Enable manual control. 
+            else if (joystick2.getThrottle() <= 0){
+                elementLift.setVoltage(6 * -joystick2.getY()); //Scale it/increase power it's given so lift has enough to move. 
             }
 
         }, elementLift));

--- a/24-25_ReefScape_9082/src/main/java/frc/robot/subsystems/ElementLift.java
+++ b/24-25_ReefScape_9082/src/main/java/frc/robot/subsystems/ElementLift.java
@@ -84,10 +84,11 @@ public class ElementLift extends SubsystemBase {
       voltage = (voltage/Math.abs(voltage))*(elementLiftConstants.liftMinVoltage+1.375);
       }
     }  
+    //else if the voltage is below the min required to hold the string tight apply a fraction of max voltage allowed to turn the motor that tightens the string. 
     else if (Math.abs(voltage) < elementLiftConstants.liftMinVoltage){
       voltage = (voltage/Math.abs(voltage))*elementLiftConstants.liftMinVoltage;
     }
-
+    //
     if (Math.abs(voltage) > elementLiftConstants.liftMaxVoltage){
       voltage = (voltage/Math.abs(voltage))*elementLiftConstants.liftMaxVoltage;
     }
@@ -141,5 +142,9 @@ public class ElementLift extends SubsystemBase {
    */
   public void resetEncoder(){
     elementLift.getEncoder().setPosition(0);
+  }
+
+  public PIDController getLiftPID() {
+    return elementLiftController; 
   }
 }


### PR DESCRIPTION
What branch does:
- Change controls from being only joystick to PID controller and joystick based.

Purpose of the changes:
- Keeps lift from going past the limits cleaner. 
- Manual controls add redundancy incase encoders stop working. 
- Keep lift from falling on its own after the driver's driven where they want to go. 

Key features and modifications:
- Continuously check minimum and maximum height.
- Manual controls added to override PID controller.
- PID controller to keep lift within upper and lower limit.

How changes were tested:
- Driving lift then letting go of joystick.
- Tried to drive below lower limit and seen if it tried to come back up.
- Tried to drive above upper limit and seen if it tried to come back down.

Required additional testing (if applicable):
- Needs to be tested with coral on field.

Breaking changes:
- NA